### PR TITLE
Remove duplicate and ignore W391 (PEP8)

### DIFF
--- a/vim_template/langs/python/python.vim
+++ b/vim_template/langs/python/python.vim
@@ -18,6 +18,7 @@ let g:jedi#completions_command = "<C-Space>"
 
 " syntastic
 let g:syntastic_python_checkers=['python', 'flake8']
+let g:syntastic_python_flake8_post_args='--ignore=W391'
 
 " vim-airline
 let g:airline#extensions#virtualenv#enabled = 1

--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -112,7 +112,6 @@ set nobackup
 set noswapfile
 
 set fileformats=unix,dos,mac
-set backspace=indent,eol,start
 set showcmd
 set shell=/bin/sh
 
@@ -160,9 +159,6 @@ set scrolloff=3
 
 "" Status bar
 set laststatus=2
-
-"" allow backspacing over everything in insert mode
-set backspace=indent,eol,start
 
 "" Use modeline overrides
 set modeline


### PR DESCRIPTION
Remove duplicate entries of ``set backspace`` and ignore **W391** on flake8 check, because this PEP8 has conflict with **W292** on VIM.