### PR TITLE
Create vim_bootstrap_editor variable on vimrc template

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -58,6 +58,7 @@ NeoBundle 'tomasr/molokai'
 NeoBundle 'sherzberg/vim-bootstrap-updater'
 
 let g:vim_bootstrap_langs = "{{ select_lang }}"
+let g:vim_bootstrap_editor = "{{editor}}"				" nvim or vim
 
 "" Custom bundles
 {% for b in bundle %}


### PR DESCRIPTION
Set a `vim_bootstrap_editor` variable for get the actual editor (vim or nvim). 
It's very important for `:VimBootstrapUpdate` command uses.