### PR TITLE
Update airline deprecated syntax

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -181,7 +181,7 @@ if exists("*fugitive#statusline")
 endif
 
 let g:airline_theme = 'powerlineish'
-let g:airline_enable_branch = 1
+let g:airline#extensions#branch#enabled = 1
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#left_sep = ' '
 let g:airline#extensions#tabline#left_alt_sep = '|'
@@ -321,7 +321,7 @@ let g:syntastic_auto_loc_list=1
 let g:syntastic_aggregate_errors = 1
 
 " vim-airline
-let g:airline_enable_syntastic = 1
+let g:airline#extensions#syntastic#enabled = 1
 
 "" Copy/Paste/Cut
 if has('unnamedplus')


### PR DESCRIPTION
When I was starting vim, I was getting this warning:

The variable g:airline_enable_syntastic is deprecated and may not work in the future. It has been replaced with g:airline#extensions#syntastic#enabled....