### PR TITLE
Remove ttyfast option from neovim

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -112,8 +112,8 @@ set smartcase
 
 "" Encoding
 set bomb
-set ttyfast
 set binary
+{{ 'set ttyfast' if editor != 'neovim' }}
 
 "" Directories for swp files
 set nobackup


### PR DESCRIPTION
Neovim removed the ttyfast option so remove it from the generated
template.  See neovim change:

https://github.com/neovim/neovim/commit/10b2a0e52980aba2d1efc072368fcaf1f33e7512