### PR TITLE
Change git commands to fugitive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Commands | Descriptions
 `,f` | Search in the project
 `,o` | Open github file/line (website), if used git in **github**
 `,sh` | Open shell terminal inside Vim
-`,ga` | git add **.**
-`,gc` | git commit -m
+`,ga` | Execute *git add* on current file
+`,gc` | git commit (splits window to write commit message)
 `,gsh` | git push
 `,gll` | git pull
 `,gs` | git status

--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -287,10 +287,10 @@ noremap <Leader>h :<C-u>split<CR>
 noremap <Leader>v :<C-u>vsplit<CR>
 
 "" Git
-noremap <Leader>ga :!git add .<CR>
-noremap <Leader>gc :!git commit -m '<C-R>="'"<CR>
-noremap <Leader>gsh :!git push<CR>
-noremap <Leader>gll :!git pull<CR>
+noremap <Leader>ga :Gwrite<CR>
+noremap <Leader>gc :Gcommit<CR>
+noremap <Leader>gsh :Gpush<CR>
+noremap <Leader>gll :Gpull<CR>
 noremap <Leader>gs :Gstatus<CR>
 noremap <Leader>gb :Gblame<CR>
 noremap <Leader>gd :Gvdiff<CR>


### PR DESCRIPTION
Small change to functionalities:

- **git add**: now adds only *current* file.

Old command added every file in the path which wasn't on the gitignore file, this is troublesome, specially for beginners

- **git commit**: splits window for commit message.

Old command could try to create a commit with empty message, if user was careless.