### PR TITLE
Add support for NeoVim terminal emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Commands | Descriptions
 `,h` | Split horizontal
 `,f` | Search in the project
 `,o` | Open github file/line (website), if used git in **github**
-`,sh` | Open shell terminal inside Vim
+`,sh` | Open shell.vim terminal inside Vim or NeoVim built-in terminal
 `,ga` | Execute *git add* on current file
 `,gc` | git commit (splits window to write commit message)
 `,gsh` | git push

--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -250,10 +250,16 @@ noremap <F3> :NERDTreeToggle<CR>
 nnoremap <silent> <leader>f :Rgrep<CR>
 let Grep_Default_Options = '-IR'
 
-" vimshell
+" vimshell.vim
 let g:vimshell_user_prompt = 'fnamemodify(getcwd(), ":~")'
 let g:vimshell_prompt =  '$ '
-nnoremap <silent> <leader>sh :VimShellCreate<CR>
+
+" terminal emulation
+if g:vim_bootstrap_editor == 'nvim'
+  nnoremap <silent> <leader>sh :terminal<CR>
+else
+  nnoremap <silent> <leader>sh :VimShellCreate<CR>
+endif
 
 "*****************************************************************************
 "" Functions


### PR DESCRIPTION
WOW! NeoVim has now a built-in terminal! :beer: 
http://neovim.org/doc/user/nvim_terminal_emulator.html#nvim-terminal-emulator

I guess vim-users can still use vim.shell plugin and neovim-users can use this new feature with `,sh` command instead of vim.shell. 