### PR TITLE
Fix deprecated airline config name

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -228,10 +228,10 @@ if !exists('g:airline_powerline_fonts')
   let g:airline_left_alt_sep      = '»'
   let g:airline_right_sep         = '◀'
   let g:airline_right_alt_sep     = '«'
-  let g:airline_branch_prefix     = '⤴' "➔, ➥, ⎇
-  let g:airline_readonly_symbol   = '⊘'
-  let g:airline_linecolumn_prefix = '¶'
-  let g:airline_paste_symbol      = 'ρ'
+  let g:airline#extensions#branch#prefix     = '⤴' "➔, ➥, ⎇
+  let g:airline#extensions#readonly#symbol   = '⊘'
+  let g:airline#extensions#linecolumn#prefix = '¶'
+  let g:airline#extensions#paste#symbol      = 'ρ'
   let g:airline_symbols.linenr    = '␊'
   let g:airline_symbols.branch    = '⎇'
   let g:airline_symbols.paste     = 'ρ'


### PR DESCRIPTION
This fix a warning when vim starts because of some deprecated variables

"The variable g:airline_branch_prefix is deprecated and my not work in
the future..."