### PR TITLE
Fix UltiSnips error when using vim 7.3

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -61,7 +61,10 @@ NeoBundle 'xolox/vim-misc'
 NeoBundle 'xolox/vim-session'
 
 "" Snippets
-NeoBundle 'SirVer/ultisnips'
+if v:version >= 704
+  NeoBundle 'SirVer/ultisnips'
+endif
+
 NeoBundle 'honza/vim-snippets'
 
 "" Color


### PR DESCRIPTION
Fixes the following error:
```
UltiSnips requires Vim >= 7.4
Press ENTER or type command to continue
```