### PR TITLE
Improve CtrlP speed with cache and Ag

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -345,11 +345,15 @@ set wildmode=list:longest,list:full
 set wildignore+=*.o,*.obj,.git,*.rbc,*.pyc,__pycache__
 let g:ctrlp_custom_ignore = '\v[\/](node_modules|target|dist)|(\.(swp|tox|ico|git|hg|svn))$'
 let g:ctrlp_user_command = "find %s -type f | grep -Ev '"+ g:ctrlp_custom_ignore +"'"
-let g:ctrlp_use_caching = 0
+let g:ctrlp_use_caching = 1
 cnoremap <C-P> <C-R>=expand("%:p:h") . "/" <CR>
 noremap <leader>b :CtrlPBuffer<CR>
 let g:ctrlp_map = '<leader>e'
 let g:ctrlp_open_new_file = 'r'
+let g:ctrlp_cache_dir = $HOME . '/.cache/ctrlp'
+if executable('ag')
+	let g:ctrlp_user_command = 'ag %s -l --nocolor -g ""'
+endif
 
 " snippets
 let g:UltiSnipsExpandTrigger="<tab>"


### PR DESCRIPTION
With cache CtrlP works really fine in big projects. If you want refresh the cache just press F5 with CtrlP opened.

CtrP use vim native globpath() for search files. If you have Ag installed in your machine, search files will be more fast. See the explanation: http://stackoverflow.com/a/22784889