### PR TITLE
Avoid duplicated imports in python file

### DIFF
--- a/vim_template/langs/python/python.vim
+++ b/vim_template/langs/python/python.vim
@@ -15,6 +15,7 @@ let g:jedi#usages_command = "<leader>n"
 let g:jedi#rename_command = "<leader>r"
 let g:jedi#show_call_signatures = "0"
 let g:jedi#completions_command = "<C-Space>"
+let g:jedi#smart_auto_mappings = 0
 
 " syntastic
 let g:syntastic_python_checkers=['python', 'flake8']


### PR DESCRIPTION
New version of jedi plugin, causes a duplicated import when you copy and paste code to vim, Example:

`from math import import sin`

Avoid this with new config:

`let g:jedi#smart_auto_mappings = 0`

Thank you @gtsalles for the tip.
