### PR TITLE
set avelino fork repo official vim-bootstrap-updater package

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -81,11 +81,10 @@ NeoBundle 'honza/vim-snippets'
 "" Color
 NeoBundle 'tomasr/molokai'
 
-"" Vim-Bootstrap Updater
-NeoBundle 'sherzberg/vim-bootstrap-updater'
+"" Vim-Bootstrap Updater by sherzberg
+NeoBundle 'avelino/vim-bootstrap-updater'
 
 "" Custom bundles
-
 {% for b in bundle -%}
 {{ bundle[b] }}
 {% endfor -%}


### PR DESCRIPTION
more than 1 year was opened a PR and we had no return of the @sherzberg
so I decided to keep a fork of official (thus keeping the credit of creator)
PR: https://github.com/sherzberg/vim-bootstrap-updater/pull/4 by @nemith
Accept PR in: https://github.com/avelino/vim-bootstrap-updater/commits/master