### PR TITLE
remove "ignore=W391" in syntastic plugin config

### DIFF
--- a/vim_template/langs/python/python.vim
+++ b/vim_template/langs/python/python.vim
@@ -19,7 +19,6 @@ let g:jedi#smart_auto_mappings = 0
 
 " syntastic
 let g:syntastic_python_checkers=['python', 'flake8']
-let g:syntastic_python_flake8_post_args='--ignore=W391'
 
 " vim-airline
 let g:airline#extensions#virtualenv#enabled = 1


### PR DESCRIPTION
After many test I come to the conclusion that it's not a a bug or an inconsistency in flake8, sorry for my old PR ( #87 )