### PR TITLE
Update vimrc

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -98,6 +98,9 @@ filetype plugin indent on
 set encoding=utf-8
 set fileencoding=utf-8
 set fileencodings=utf-8
+set bomb
+set binary
+{{ 'set ttyfast' if editor.name != 'nvim' }}
 
 "" Fix backspace indent
 set backspace=indent,eol,start
@@ -119,11 +122,6 @@ set hlsearch
 set incsearch
 set ignorecase
 set smartcase
-
-"" Encoding
-set bomb
-set binary
-{{ 'set ttyfast' if editor.name != 'nvim' }}
 
 "" Directories for swp files
 set nobackup


### PR DESCRIPTION
when starting vim 'noexpandtab' is set.

Found this via https://github.com/avelino/vim-bootstrap/issues/193 .

```
set expandtab
```

after 
```
set binary
```

fixes this