### PR TITLE
Update config files paths for neovim

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"text/template"
 )
 
@@ -30,13 +31,16 @@ func Generate(obj *Object) (buffer string) {
 	config := Config{}
 	switch obj.Editor {
 	case "nvim":
-		config.BaseDir = "~/.config/" + obj.Editor
+		config.BaseDir = "~/.config/nvim"
+		config.Rc = filepath.Join(config.BaseDir, "init.vim")
+		config.LocalRc = filepath.Join(config.BaseDir, "local_init.vim")
+		config.LocalBundle = filepath.Join(config.BaseDir, "local_bundles.vim")
 	default:
 		config.BaseDir = "~/." + obj.Editor
+		config.Rc = config.BaseDir + "rc"
+		config.LocalRc = config.Rc + ".local"
+		config.LocalBundle = config.Rc + ".local.bundles"
 	}
-	config.Rc = config.BaseDir + "rc"
-	config.LocalRc = config.Rc + ".local"
-	config.LocalBundle = config.Rc + ".local.bundles"
 
 	obj.Config = &config
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/avelino/vim-bootstrap
 import:
-- package: github.com/codegangsta/negroni
+- package: github.com/urfave/negroni
   version: ^0.2.0
 - package: github.com/gorilla/mux
   version: ^1.1.0

--- a/vim-bootstrap.go
+++ b/vim-bootstrap.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/avelino/vim-bootstrap/generate"
 	"github.com/avelino/vim-bootstrap/web"
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/gorilla/mux"
 )
 


### PR DESCRIPTION
    Neovim follows xdg style directories which means that all files
    live under ~/.config/nvim.  When the generator was switches to go
    the assumptions was that the config files were named the same as
    vim but just under .config.  This assumption is incorrect.
    
    This restores the same functionality and names as the previous
    python generator.
    
      Basedir      : ~/.config/nvim
      Main rc file : ~/.config/nvim/init.vim
      Local rc file: ~/.config/nvim/local_init.vim
      Local bundle : ~/.config/nvim/local_bundles.vim
