### PR TITLE
Prevent E216 error on older versions of vim

### DIFF
--- a/vim_template/langs/go/go.vim
+++ b/vim_template/langs/go/go.vim
@@ -43,7 +43,9 @@ autocmd BufNewFile,BufRead *.go setlocal noexpandtab tabstop=4 shiftwidth=4
 
 augroup completion_preview_close
   autocmd!
-  autocmd CompleteDone * if !&previewwindow && &completeopt =~ 'preview' | silent! pclose | endif
+  if v:version > 703 || v:version == 703 && has('patch598')
+    autocmd CompleteDone * if !&previewwindow && &completeopt =~ 'preview' | silent! pclose | endif
+  endif
 augroup END
 
 augroup go


### PR DESCRIPTION
Older versions of vim do not have CompleteDone. Test vim version before attempting to use CompleteDone.