### PR TITLE
changing the vimrc to accept my own shell emulator

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -127,7 +127,12 @@ set noswapfile
 
 set fileformats=unix,dos,mac
 set showcmd
-set shell=/bin/sh
+
+if exists('$SHELL')
+    set shell=$SHELL
+else
+    set shell=/bin/sh
+endif
 
 " session management
 let g:session_directory = "{{.Config.BaseDir}}/session"


### PR DESCRIPTION
many people like to use others shell emulators like oh my zsh, I changed the vimrc to use the global variable $SHELL for use my own shell emulator.