### PR TITLE
Add 'requirements.txt.vim' in Python's vim-template

### DIFF
--- a/vim_template/langs/python/python.bundle
+++ b/vim_template/langs/python/python.bundle
@@ -1,2 +1,3 @@
 "" Python Bundle
 Plug 'davidhalter/jedi-vim'
+Plug 'raimon49/requirements.txt.vim', {'for': 'requirements'}


### PR DESCRIPTION
I added 'requirements.txt.vim' to Python's vim_template. 

Users can edit 'requirements.txt.vim' like this:

![edit_requirements.txt](https://cloud.githubusercontent.com/assets/221802/11379923/5cbb4862-9336-11e5-8963-217b2d7df397.png)

I am the author of that plugin and I am sympathizing with the Vim Bootstrap project.