### PR TITLE
Bugfix: matchit not found in neovim. Fix #257

### DIFF
--- a/vim_template/langs/ruby/ruby.vim
+++ b/vim_template/langs/ruby/ruby.vim
@@ -26,7 +26,11 @@ map <Leader>l :call RunLastSpec()<CR>
 map <Leader>a :call RunAllSpecs()<CR>
 
 " For ruby refactory
-packadd! matchit
+if has('nvim')
+  runtime! macros/matchit.vim
+else
+  packadd! matchit
+endif
 
 " Ruby refactory
 nnoremap <leader>rap  :RAddParameter<cr>


### PR DESCRIPTION
Check if running on neovim or vim, and correctly loads matchit package.
