### PR TITLE
Go improvements based on a post

### DIFF
--- a/vim_template/langs/go/go.vim
+++ b/vim_template/langs/go/go.vim
@@ -24,7 +24,20 @@ endfunction
 let g:go_list_type = "quickfix"
 let g:go_fmt_command = "goimports"
 let g:go_fmt_fail_silently = 1
+let g:go_auto_type_info = 1
 let g:syntastic_go_checkers = ['golint', 'govet']
+let g:go_metalinter_enabled = [
+    \ 'deadcode',
+    \ 'errcheck',
+    \ 'gas',
+    \ 'goconst',
+    \ 'gocyclo',
+    \ 'golint',
+    \ 'gosimple',
+    \ 'ineffassign',
+    \ 'vet',
+    \ 'vetshadow'
+\]
 let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
 
 let g:go_highlight_types = 1
@@ -33,13 +46,14 @@ let g:go_highlight_functions = 1
 let g:go_highlight_methods = 1
 let g:go_highlight_operators = 1
 let g:go_highlight_build_constraints = 1
+let g:go_highlight_structs = 1
 let g:go_highlight_generate_tags = 1
 let g:go_highlight_space_tab_error = 0
 let g:go_highlight_array_whitespace_error = 0
 let g:go_highlight_trailing_whitespace_error = 0
-let g:go_highlight_extra_types = 0
+let g:go_highlight_extra_types = 1
 
-autocmd BufNewFile,BufRead *.go setlocal noexpandtab tabstop=4 shiftwidth=4
+autocmd BufNewFile,BufRead *.go setlocal noexpandtab tabstop=4 shiftwidth=4 softtabstop=4
 
 augroup completion_preview_close
   autocmd!


### PR DESCRIPTION
Improvements in go based on [this](https://medium.com/@sebdah/my-neovim-setup-for-go-7f7b6e805876) post.

Add softtabstop, because if softtabstop equals tabstop and expandtab is not set, vim will always use tabs.

Add more linters on gometalinter.

Auto type info to move the cursor over a variable or such to see what type it is. Or move it to a function call and see it’s input parameters and return values.

More highlights, If it affects performance, we can rethink this.
