### PR TITLE
[scala] sbt.vim is not working with python 3

### DIFF
--- a/vim_template/langs/scala/scala.bundle
+++ b/vim_template/langs/scala/scala.bundle
@@ -1,4 +1,6 @@
-" sbt-vim
-Plug 'ktvoelker/sbt-vim'
+if has('python')
+    " sbt-vim
+    Plug 'ktvoelker/sbt-vim'
+endif
 " vim-scala
 Plug 'derekwyatt/vim-scala'


### PR DESCRIPTION
If your vim is not compiled with python2 support an error is handled with  this plugin.
