### PR TITLE
Use Ale instead of Syntastic when supported

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -43,7 +43,11 @@ Plug 'vim-scripts/CSApprox'
 Plug 'bronson/vim-trailing-whitespace'
 Plug 'Raimondi/delimitMate'
 Plug 'majutsushi/tagbar'
-Plug 'scrooloose/syntastic'
+if has('job')
+  Plug 'w0rp/ale'
+else
+  Plug 'scrooloose/syntastic'
+endif
 Plug 'Yggdroot/indentLine'
 Plug 'avelino/vim-bootstrap-updater'
 Plug 'sheerun/vim-polyglot'
@@ -224,7 +228,6 @@ endif
 
 " vim-airline
 let g:airline_theme = 'powerlineish'
-let g:airline#extensions#syntastic#enabled = 1
 let g:airline#extensions#branch#enabled = 1
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tagbar#enabled = 1
@@ -381,14 +384,19 @@ let g:UltiSnipsJumpForwardTrigger="<tab>"
 let g:UltiSnipsJumpBackwardTrigger="<c-b>"
 let g:UltiSnipsEditSplit="vertical"
 
-" syntastic
-let g:syntastic_always_populate_loc_list=1
-let g:syntastic_error_symbol='✗'
-let g:syntastic_warning_symbol='⚠'
-let g:syntastic_style_error_symbol = '✗'
-let g:syntastic_style_warning_symbol = '⚠'
-let g:syntastic_auto_loc_list=1
-let g:syntastic_aggregate_errors = 1
+if !has('job')
+  " syntastic
+  let g:syntastic_always_populate_loc_list=1
+  let g:syntastic_error_symbol='✗'
+  let g:syntastic_warning_symbol='⚠'
+  let g:syntastic_style_error_symbol = '✗'
+  let g:syntastic_style_warning_symbol = '⚠'
+  let g:syntastic_auto_loc_list=1
+  let g:syntastic_aggregate_errors = 1
+
+  " airline extension for syntastic
+  let g:airline#extensions#syntastic#enabled = 1
+endif
 
 " Tagbar
 nmap <silent> <F4> :TagbarToggle<CR>


### PR DESCRIPTION
# Ale support for Vim 8

This PR will check for `+job` support, and if it is found, install Ale instead of Syntastic for a much better user experience.

## Test process:

1. Run Vim 8 (with job support) with the vimrc & check that Ale works correctly.
2. Run Vim 7 (without job support) with the vimrc & check that Syntastic works correctly.

## Misc

I'll grant that I couldn't quite figure out how to build the project locally, so I just stripped out any lines containing `{{`/`}}` during testing.

This is also my first time contributing to this project, so please let me know if there are other changes I need to make in order to support this addition (build process, configs, etc).

Resolves #278.