### PR TITLE
Use Config.BaseDir for autoload plug script

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -15,7 +15,7 @@ if !filereadable(vimplug_exists)
   endif
   echo "Installing Vim-Plug..."
   echo ""
-  silent exec "!\curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
+  silent exec "!\curl -fLo " . vimplug_exists . " --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
   let g:not_finish_vimplug = "yes"
 
   autocmd VimEnter * PlugInstall


### PR DESCRIPTION
For neovim, we must store plug.vim under ~/.config/nvim/autoload

