### PR TITLE
Added Back for Python

### DIFF
--- a/vim_template/langs/python/python.bundle
+++ b/vim_template/langs/python/python.bundle
@@ -1,3 +1,4 @@
 "" Python Bundle
 Plug 'davidhalter/jedi-vim'
+Plug 'python/black'
 Plug 'raimon49/requirements.txt.vim', {'for': 'requirements'}

--- a/vim_template/langs/python/python.vim
+++ b/vim_template/langs/python/python.vim
@@ -17,6 +17,9 @@ let g:jedi#show_call_signatures = "0"
 let g:jedi#completions_command = "<C-Space>"
 let g:jedi#smart_auto_mappings = 0
 
+" black
+autocmd BufWritePre *.py execute ':Black'
+
 " ale
 :call extend(g:ale_linters, {
     \'python': ['flake8'], })


### PR DESCRIPTION
This PR, added the support for Black, the uncompromising Python code formatter.
It is directly from the Python team.
This plugin format the python code. Very simple but very strong.